### PR TITLE
Disable Testing in CI Pipeline

### DIFF
--- a/.tekton/pipelinerun.yaml
+++ b/.tekton/pipelinerun.yaml
@@ -121,18 +121,20 @@ spec:
           - name: source
             workspace: source
 
-      - name: go-test
-        when:
-          - input: "$(params.runOptional)"
-            operator: in
-            values: ["true"]
-        taskRef:
-          name: go-test-task
-        runAfter:
-          - go-lint
-        workspaces:
-          - name: source
-            workspace: source
+    # Testing currently disabled, this repo is a fork of a public repo.
+    # We have to configure cluster to match tests, or better, change the tests.
+    #  - name: go-test
+    #    when:
+    #      - input: "$(params.runOptional)"
+    #        operator: in
+    #        values: ["true"]
+    #    taskRef:
+    #      name: go-test-task
+    #    runAfter:
+    #      - go-lint
+    #    workspaces:
+    #      - name: source
+    #        workspace: source
 
       - name: go-build
         when:


### PR DESCRIPTION
Testing currently disabled, this repo is a fork of a public repo.
We have to configure cluster to match tests, or better, change the tests.