### PR TITLE
fix: basic container image builds for linux

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,4 @@ WORKDIR /
 COPY --from=builder /workspace/bin/epp /app/epp
 USER 65532:65532
 
-CMD ["sleep", "infinity"]
-
-
+ENTRYPOINT ["/app/epp"]

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
+TARGETOS ?= linux
+TARGETARCH ?= amd64
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -474,13 +477,13 @@ buildah-build: check-builder load-version-json ## Build and push image (multi-ar
 	fi
 
 .PHONY:	image-build
-image-build: check-container-tool load-version-json ## Build Docker image ## Build Docker image using $(CONTAINER_TOOL)
-	@printf "\033[33;1m==== Building Docker image $(IMG) ====\033[0m\n"
+image-build: check-container-tool load-version-json ## Build container image using $(CONTAINER_TOOL)
+	@printf "\033[33;1m==== Building container image $(IMG) ====\033[0m\n"
 	$(CONTAINER_TOOL) build --build-arg TARGETOS=$(TARGETOS) --build-arg TARGETARCH=$(TARGETARCH) -t $(IMG) .
 
 .PHONY: image-push
-image-push: check-container-tool load-version-json ## Push Docker image $(IMG) to registry
-	@printf "\033[33;1m==== Pushing Docker image $(IMG) ====\033[0m\n"
+image-push: check-container-tool load-version-json ## Push container image $(IMG) to registry
+	@printf "\033[33;1m==== Pushing container image $(IMG) ====\033[0m\n"
 	$(CONTAINER_TOOL) push $(IMG)
 
 ##@ Install/Uninstall Targets

--- a/pkg/epp/scheduling/scorer.go
+++ b/pkg/epp/scheduling/scorer.go
@@ -17,7 +17,7 @@ limitations under the License.
 package scheduling
 
 import (
-	"fmt"
+	"errors"
 	"math/rand/v2"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -66,7 +66,7 @@ func (sm *ScorerMng) scoreTargets(ctx *types.Context, pods []*types.PodMetrics) 
 	}
 
 	if len(validPods) == 0 {
-		return nil, fmt.Errorf("Empty list of valid pods to score")
+		return nil, errors.New("Empty list of valid pods to score")
 	}
 
 	// add scores from all scorers


### PR DESCRIPTION
Fixes #8 

With this change you'll be able to properly apply arguments ([example](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/config/manifests/inferencepool-resources.yaml#L55)).

Also fixes #9 