### PR TITLE
Minor fixes to enable image building matching GIE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,11 +396,11 @@ SHELL := /usr/bin/env bash
 PROJECT_NAME ?= gateway-api-inference-extension
 DEV_VERSION ?= 0.0.1
 PROD_VERSION ?= 0.0.0
-IMAGE_TAG_BASE ?= quay.io/vllm-d/$(PROJECT_NAME)
+IMAGE_TAG_BASE ?= quay.io/vllm-d/$(PROJECT_NAME)/epp
 IMG = $(IMAGE_TAG_BASE):$(DEV_VERSION)
 NAMESPACE ?= hc4ai-operator
 
-CONTAINER_TOOL := $(shell command -v docker >/dev/null 2>&1 && echo docker || command -v podman >/dev/null 2>&1 && echo podman || echo "")
+# CONTAINER_TOOL := $(shell command -v docker >/dev/null 2>&1 && echo docker || command -v podman >/dev/null 2>&1 && echo podman || echo "")
 BUILDER := $(shell command -v buildah >/dev/null 2>&1 && echo buildah || echo $(CONTAINER_TOOL))
 PLATFORMS ?= linux/amd64 # linux/arm64 # linux/s390x,linux/ppc64le
 


### PR DESCRIPTION
- CONTAINER_TOOL setting commented out until can be fixed correctly (Ref #7)
- image name was missing `epp` as last element in tag

@clubanderson please note addition of `epp` in image path (to match original GIE configuration of image names) and confirm it has no undesirable side effects in the rest of the pipeline