### PR TITLE
Patch Istio deployment to use 1Gi of mem

### DIFF
--- a/deploy/components/istio-control-plane/deployments.yaml
+++ b/deploy/components/istio-control-plane/deployments.yaml
@@ -123,7 +123,7 @@ spec:
         resources:
           requests:
             cpu: 500m
-            memory: 2048Mi
+            memory: 1024Mi
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
In a Kind cluster, 2Gi could cause the pod to not start.