### PR TITLE
Setup the Istio service to be a NodePort service and not a ClusterIP service

### DIFF
--- a/deploy/environments/dev/kind/gateway.yaml
+++ b/deploy/environments/dev/kind/gateway.yaml
@@ -1,0 +1,6 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: inference-gateway
+  annotations:
+    networking.istio.io/service-type: NodePort

--- a/deploy/environments/dev/kind/kustomization.yaml
+++ b/deploy/environments/dev/kind/kustomization.yaml
@@ -13,6 +13,10 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
+- services.yaml
 - ../../../components/istio-control-plane/
 - ../../../components/vllm-sim/
 - ../../../components/inference-gateway/
+
+patches:
+- path: gateway.yaml

--- a/deploy/environments/dev/kind/services.yaml
+++ b/deploy/environments/dev/kind/services.yaml
@@ -1,0 +1,28 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    networking.istio.io/service-type: NodePort
+  labels:
+    gateway.istio.io/managed: istio.io-gateway-controller
+    gateway.networking.k8s.io/gateway-name: inference-gateway
+    istio.io/enable-inference-extproc: "true"
+  name: inference-gateway-istio
+  namespace: default
+spec:
+  type: NodePort
+  selector:
+    gateway.networking.k8s.io/gateway-name: inference-gateway
+  ports:
+  - appProtocol: tcp
+    name: status-port
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+    nodePort: 32021
+  - appProtocol: http
+    name: default
+    port: 80
+    protocol: TCP
+    targetPort: 80
+    nodePort: 30080


### PR DESCRIPTION
The current setup for running the end to end scenario under Kind, requires the use of `kubectl port-forward` to send requests to the configured Istio ingress server.

This PR changes the ingress service to be a NodePort service rather than a ClusterIP service. This removes the need to run `kubectl port-forward`.

The host port that the service's nodePort is mapped to, defaults to 30080. The user can use the GATEWAY_HOST_PORT environment variable, to set this port to another value as desired.

