### PR TITLE
Report lint errors on new code only

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,6 +4,8 @@ run:
 
 # Settings related to issues
 issues:
+  # Report issues on new code only (since we're brining in from upstream)
+  new: true
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin


### PR DESCRIPTION
Since we're on a fork, does not make sense to test and fix existing code from upstream