### PR TITLE
fix: Correct the setup of the KGateway Envoy service to be a proper NodePort service

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -46,6 +46,16 @@ local container runtime and deploy the development stack into the `default`
 namespace. Instrutions will be provided on how to access the `Gateway` and send
 requests for testing.
 
+By default the created inference gateway, can be accessed on port 30080. This can
+be overriden to any free port in the range of 30000 to 32767, by running the above
+command as follows:
+
+```console
+GATEWAY_HOST_PORT=<selected-port> make environment.dev.kind
+```
+**Where:** &lt;selected-port&gt; is the port on your local machine you want to use to
+access the inference gatyeway.
+
 > **NOTE**: If you require significant customization of this environment beyond
 > what the standard deployment provides, you can use the `deploy/components`
 > with `kustomize` to build your own highly customized environment. You can use

--- a/deploy/environments/dev/kind-kgateway/gateway-parameters.yaml
+++ b/deploy/environments/dev/kind-kgateway/gateway-parameters.yaml
@@ -1,0 +1,13 @@
+apiVersion: gateway.kgateway.dev/v1alpha1
+kind: GatewayParameters
+metadata:
+  name: custom-gw-params
+spec:
+  kube: 
+    service:
+      type: NodePort
+      extraLabels:
+        gateway: inference-gateway
+    podTemplate:
+      extraLabels:
+        gateway: inference-gateway

--- a/deploy/environments/dev/kind-kgateway/kustomization.yaml
+++ b/deploy/environments/dev/kind-kgateway/kustomization.yaml
@@ -16,6 +16,7 @@ resources:
 - services.yaml
 - ../../../components/kgateway-control-plane/
 - ../../../components/vllm-sim/
+- gateway-parameters.yaml
 - ../../../components/inference-gateway/
 
 patches:

--- a/deploy/environments/dev/kind-kgateway/patch-gateways.yaml
+++ b/deploy/environments/dev/kind-kgateway/patch-gateways.yaml
@@ -4,3 +4,8 @@ metadata:
   name: inference-gateway
 spec:
   gatewayClassName: kgateway
+  infrastructure:
+    parametersRef:
+      name: custom-gw-params
+      group: gateway.kgateway.dev
+      kind: GatewayParameters

--- a/deploy/environments/dev/kind-kgateway/services.yaml
+++ b/deploy/environments/dev/kind-kgateway/services.yaml
@@ -1,28 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  annotations:
-    networking.istio.io/service-type: NodePort
   labels:
-    gateway.istio.io/managed: istio.io-gateway-controller
+    app.kubernetes.io/instance: inference-gateway
+    app.kubernetes.io/name: inference-gateway
+    app.kubernetes.io/version: v2.0.0
     gateway.networking.k8s.io/gateway-name: inference-gateway
-    istio.io/enable-inference-extproc: "true"
-  name: inference-gateway-istio
+    kgateway: kube-gateway
+  name: inference-gateway
   namespace: default
 spec:
   type: NodePort
   selector:
+    app.kubernetes.io/instance: inference-gateway
+    app.kubernetes.io/name: inference-gateway
     gateway.networking.k8s.io/gateway-name: inference-gateway
   ports:
-  - appProtocol: tcp
-    name: status-port
-    port: 15021
-    protocol: TCP
-    targetPort: 15021
-    nodePort: 32021
-  - appProtocol: http
-    name: default
-    port: 80
-    protocol: TCP
-    targetPort: 80
-    nodePort: 30080
+    - name: default
+      nodePort: 30080
+      port: 80
+      protocol: TCP
+      targetPort: 8080

--- a/scripts/kind-dev-env.sh
+++ b/scripts/kind-dev-env.sh
@@ -117,7 +117,7 @@ kustomize build --enable-helm deploy/environments/dev/kind-kgateway \
 	| kubectl --context ${KUBE_CONTEXT} apply -f -
 
 # Wait for all control-plane pods to be ready
-kubectl --context ${KUBE_CONTEXT} -n kgateway-system wait --for=condition=Ready --all pods --timeout=300s
+kubectl --context ${KUBE_CONTEXT} -n kgateway-system wait --for=condition=Ready --all pods --timeout=360s
 
 # Wait for all pods to be ready
 kubectl --context ${KUBE_CONTEXT} wait --for=condition=Ready --all pods --timeout=300s


### PR DESCRIPTION
This PR corrects setup of the KGateway Envoy's service to be a proper NodePort service.

To do this:
 
  1) The created service was renamed to that which is used by KGateway's Controller for the Envoy pod
  2) A KGateway GatewayParameters object was added to set the Service type to NodePort. Unfortunately, this
      by itself is not enough, as one can't set the nodePort that the service will be mapped to.