### PR TITLE
Sessions support is removed from datastore, server and scheduler

### DIFF
--- a/pkg/epp/datastore/datastore.go
+++ b/pkg/epp/datastore/datastore.go
@@ -36,9 +36,7 @@ import (
 )
 
 const (
-	ModelNameIndexKey              = "spec.modelName"
-	sessionKeepAliveTime           = 60 * time.Minute // How long should an idle session be kept alive
-	sessionKeepAliveCheckFrequency = 15 * time.Minute // How often to check for overly idle sessions
+	ModelNameIndexKey = "spec.modelName"
 )
 
 var (
@@ -71,9 +69,6 @@ type Datastore interface {
 	PodUpdateOrAddIfNotExist(pod *corev1.Pod) bool
 	PodDelete(namespacedName types.NamespacedName)
 
-	SetPodForSession(sessionID string, pod *backendmetrics.Pod)
-	GetPodForSession(sessionID string) *backendmetrics.Pod
-
 	// Clears the store state, happens when the pool gets deleted.
 	Clear()
 }
@@ -84,11 +79,8 @@ func NewDatastore(parentCtx context.Context, pmf *backendmetrics.PodMetricsFacto
 		poolAndModelsMu: sync.RWMutex{},
 		models:          make(map[string]*v1alpha2.InferenceModel),
 		pods:            &sync.Map{},
-		sessions:        &sync.Map{},
 		pmf:             pmf,
 	}
-
-	go store.cleanupSessions(sessionKeepAliveCheckFrequency, sessionKeepAliveTime, parentCtx)
 
 	return store
 }
@@ -103,9 +95,7 @@ type datastore struct {
 	models map[string]*v1alpha2.InferenceModel
 	// key: types.NamespacedName, value: backendmetrics.PodMetrics
 	pods *sync.Map
-	// key: session id, value: *backendmetrics.Pod
-	sessions *sync.Map
-	pmf      *backendmetrics.PodMetricsFactory
+	pmf  *backendmetrics.PodMetricsFactory
 }
 
 func (ds *datastore) Clear() {
@@ -335,56 +325,6 @@ func (ds *datastore) podResyncAll(ctx context.Context, ctrlClient client.Client)
 type sessionInfo struct {
 	pod *backendmetrics.Pod
 	lru time.Time
-}
-
-// cleanup Cleans up the set of stored session information by removing information
-// of old sessions.
-func (ds *datastore) cleanupSessions(keepAliveCheckFrequency time.Duration, sessionKeepAlive time.Duration, ctx context.Context) {
-	logger := log.FromContext(ctx)
-
-	logger.Info("Session-affinity cleanup started")
-	ticker := time.NewTicker(keepAliveCheckFrequency)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			logger.Info("Session-affinity cleanup stopped:")
-			return
-		case now := <-ticker.C:
-			logger.Info("Session affinity checking")
-			ds.sessions.Range(
-				func(sessionID any, rawSessionInfo any) bool {
-					if sessionInfo, ok := rawSessionInfo.(*sessionInfo); ok {
-						if now.Sub(sessionInfo.lru) > sessionKeepAlive {
-							// Session is stale, remove it
-							ds.sessions.Delete(sessionID)
-						}
-					} else {
-						// Value is not of the correct type, remove it
-						ds.sessions.Delete(sessionID)
-					}
-					return true
-				})
-		}
-	}
-}
-
-func (ds *datastore) SetPodForSession(sessionID string, pod *backendmetrics.Pod) {
-	ds.sessions.Store(sessionID, &sessionInfo{
-		pod: pod,
-		lru: time.Now(),
-	})
-}
-
-func (ds *datastore) GetPodForSession(sessionID string) *backendmetrics.Pod {
-	if value, ok := ds.sessions.Load(sessionID); ok {
-		if sessionInfo, ok := value.(*sessionInfo); ok {
-			return sessionInfo.pod
-		}
-	}
-
-	return nil
 }
 
 func selectorFromInferencePoolSelector(selector map[v1alpha2.LabelKey]v1alpha2.LabelValue) labels.Selector {

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -21,11 +21,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	extProcPb "github.com/envoyproxy/go-control-plane/envoy/service/ext_proc/v3"
-	"github.com/google/uuid"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	schedulingtypes "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
@@ -70,9 +68,8 @@ func (s *StreamingServer) HandleRequestBody(
 		Headers:             reqCtx.RequestHeaders,
 		ResolvedTargetModel: modelName,
 		Critical:            modelObj.Spec.Criticality != nil && *modelObj.Spec.Criticality == v1alpha2.Critical,
-		SessionID:           reqCtx.SessionID,
 	}
-	logger.V(logutil.DEBUG).Info("LLM request assembled", "request", llmReq, "session id", reqCtx.SessionID)
+	logger.V(logutil.DEBUG).Info("LLM request assembled", "request", llmReq)
 
 	var err error
 	// Update target models in the body.
@@ -135,16 +132,6 @@ func (s *StreamingServer) HandleRequestBody(
 
 func (s *StreamingServer) HandleRequestHeaders(ctx context.Context, reqCtx *RequestContext, req *extProcPb.ProcessingRequest_RequestHeaders) error {
 	reqCtx.RequestReceivedTimestamp = time.Now()
-
-	for _, header := range req.RequestHeaders.Headers.GetHeaders() {
-		value := string(header.RawValue)
-		if strings.ToLower(header.Key) == strings.ToLower(SessionIDHeader) && value != "" {
-			reqCtx.SessionID = value
-		}
-	}
-	if reqCtx.SessionID == "" {
-		reqCtx.SessionID = uuid.NewString()
-	}
 
 	// an EoS in the request headers means this request has no body or trailers.
 	if req.RequestHeaders.EndOfStream {

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -93,7 +93,6 @@ type Scheduler struct {
 
 type Datastore interface {
 	PodGetAll() []backendmetrics.PodMetrics
-	GetPodForSession(SessionID string) *backendmetrics.Pod
 }
 
 // Schedule finds the target pod based on metrics and the requested lora adapter.


### PR DESCRIPTION
Sessions support is removed from datastore, server and scheduler  - to be added later to 'session affinity scorer'