### PR TITLE
pd filter returns full url of the port

### DIFF
--- a/pkg/epp/scheduling/plugins/filter/filter_test.go
+++ b/pkg/epp/scheduling/plugins/filter/filter_test.go
@@ -51,7 +51,7 @@ func TestFilter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := types.NewSchedulingContext(context.Background(), test.req, test.input)
+			ctx := types.NewSchedulingContext(context.Background(), test.req, test.input, 0)
 			got := test.filter.Filter(ctx, test.input)
 
 			if diff := cmp.Diff(test.output, got); diff != "" {
@@ -186,7 +186,7 @@ func TestFilterFunc(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ctx := types.NewSchedulingContext(context.Background(), test.req, test.input)
+			ctx := types.NewSchedulingContext(context.Background(), test.req, test.input, 0)
 			got := test.f(ctx, test.input)
 
 			if diff := cmp.Diff(test.output, got); diff != "" {
@@ -243,7 +243,7 @@ func TestLoRASoftAffinityDistribution(t *testing.T) {
 			},
 		},
 	}
-	ctx := types.NewSchedulingContext(context.Background(), req, pods)
+	ctx := types.NewSchedulingContext(context.Background(), req, pods, 0)
 
 	// Run the filter function multiple times and count the results
 	affinityCount := 0

--- a/pkg/epp/scheduling/plugins/filter/pd_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/pd_filter.go
@@ -16,6 +16,7 @@ limitations under the License.
 package filter
 
 import (
+	"fmt"
 	"math/rand/v2"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics"
@@ -55,7 +56,7 @@ func prefillDecodeFilterFunc(ctx *types.SchedulingContext, pods []types.Pod) []t
 	if len(pPods) > 0 {
 		// select a random prefill pod
 		randomIndex := rand.IntN(len(pPods))
-		ctx.MutatedHeaders[prefillPodHeader] = pPods[randomIndex].GetPod().NamespacedName.String()
+		ctx.MutatedHeaders[prefillPodHeader] = fmt.Sprintf("http://%s:%d", pPods[randomIndex].GetPod().Address, ctx.TargetPort)
 	}
 
 	if len(dPods) > 1 {

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -21,10 +21,13 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	k8stypes "k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/gateway-api-inference-extension/api/v1alpha2"
 	backendmetrics "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/backend/metrics" // Import config for thresholds
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/types"
+	testutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/testing"
 )
 
 // Tests the default scheduler configuration and expected behavior.
@@ -482,6 +485,10 @@ func TestSchedulePlugins(t *testing.T) {
 
 type fakeDataStore struct {
 	pods []*backendmetrics.FakePodMetrics
+}
+
+func (fds *fakeDataStore) PoolGet() (*v1alpha2.InferencePool, error) {
+	return &testutil.MakeInferencePool("my-pool").TargetPortNumber(0).InferencePool, nil
 }
 
 func (fds *fakeDataStore) PodGetAll() []backendmetrics.PodMetrics {

--- a/pkg/epp/scheduling/types/types.go
+++ b/pkg/epp/scheduling/types/types.go
@@ -59,6 +59,7 @@ type SchedulingContext struct {
 	Logger         logr.Logger
 	Req            *LLMRequest
 	PodsSnapshot   []Pod
+	TargetPort     int32
 	MutatedHeaders map[string]string
 }
 
@@ -82,13 +83,14 @@ type PodMetrics struct {
 	*backendmetrics.Metrics
 }
 
-func NewSchedulingContext(ctx context.Context, req *LLMRequest, pods []Pod) *SchedulingContext {
+func NewSchedulingContext(ctx context.Context, req *LLMRequest, pods []Pod, targetPort int32) *SchedulingContext {
 	logger := log.FromContext(ctx).WithValues("request", req)
 	return &SchedulingContext{
 		Context:        ctx,
 		Logger:         logger,
 		Req:            req,
 		PodsSnapshot:   pods,
+		TargetPort:     targetPort,
 		MutatedHeaders: make(map[string]string),
 	}
 }


### PR DESCRIPTION
this PR adds the inference pool target port to the scheduling context and then use it in P/D filter in order to put a full url in the header.

please pay attention that this is a temp fix to unblock PD development and not intended to be pushed to upstream.
for a long term solution, the routing team will think what is the best solution and how to solve this issue elegantly.

related to issue #93. 
the issue will remain open until we decide on a long term solution and push a PR to upstream. 