### PR TITLE
[DO NOT MERGE] Renamed Scheduler APIs to better reflect their usage.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,4 +31,8 @@ go.work.sum
 # generated docs
 site
 
+# tokenizer lib
+lib
+
+# local configuration files
 .envrc

--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,5 @@ go.work.sum
 
 # generated docs
 site
+
+.envrc

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
     - makezero
     - errcheck
     - goconst
-    - goimports
     - gosimple
     - ineffassign
     - nakedret

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,6 +17,8 @@ issues:
     
 linters:
   disable-all: true
+  disable:
+    - goanalysis_metalinter
   enable:
     - copyloopvar
     - dupword
@@ -37,7 +39,7 @@ linters:
     - nakedret
     - prealloc
     - unparam
-    # - unused
+    - unused
 
 linters-settings:
   revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,34 +12,32 @@ issues:
   exclude-dirs:
     - bin
   # Files to exclude from linting
-  exclude-files:
-    - pkg/epp/server/runserver_test.go
+  # exclude-files:
+  #   - pkg/epp/server/runserver_test.go
     
 linters:
   disable-all: true
-  disable:
-    - goanalysis_metalinter
   enable:
     - copyloopvar
-    - dupword
-    - durationcheck
-    - fatcontext
-    - ginkgolinter
-    - gocritic
-    - govet        
-    - loggercheck
-    - misspell
-    - perfsprint
-    - revive
-    - unconvert
-    - makezero
-    - errcheck
-    - goconst
-    - ineffassign
-    - nakedret
-    - prealloc
-    - unparam
-    - unused
+    # - dupword
+    # - durationcheck
+    # - fatcontext
+    # - ginkgolinter
+    # - gocritic
+    # - govet        
+    # - loggercheck
+    # - misspell
+    # - perfsprint
+    # - revive
+    # - unconvert
+    # - makezero
+    # - errcheck
+    # - goconst
+    # - ineffassign
+    # - nakedret
+    # - prealloc
+    # - unparam
+    # - unused
 
 linters-settings:
   revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -11,6 +11,8 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
+  exclude-files:
+    - '^pkg/epp/server/runserver_test\.go$'
     
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   timeout: 5m
   allow-parallel-runners: true
-
+    
 # Settings related to issues
 issues:
   # Report issues on new code only (since we're brining in from upstream)
@@ -17,27 +17,23 @@ linters:
     - dupword
     - durationcheck
     - fatcontext
-    - ginkgolinter
-    - gocritic
-    - govet
-    - loggercheck
-    - misspell
-    - perfsprint
-    - revive
-    - unconvert
-    - makezero
-    - errcheck
-    - goconst
-    - gofmt
-    - goimports
-    - gosimple
-    - ineffassign
-    - nakedret
-    - prealloc
-    - typecheck
-    - unparam
-    - unused
-    
+    # - ginkgolinter
+    # - gocritic
+    # - govet        
+    # - loggercheck
+    # - misspell
+    # - perfsprint
+    # - revive
+    # - unconvert
+    # - makezero
+    # - errcheck
+    # - goconst
+    # - ineffassign
+    # - nakedret
+    # - prealloc
+    # - unparam
+    # - unused
+
 linters-settings:
   revive:
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,6 @@
 run:
   timeout: 5m
   allow-parallel-runners: true
-  skip-files:
-    - '^pkg/epp/server/runserver_test\.go$'
     
 # Settings related to issues
 issues:
@@ -11,6 +9,8 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
+  exclude-files:
+    - '^pkg/epp/server/runserver_test\.go$'
     
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,7 +18,7 @@ linters:
     - durationcheck
     - fatcontext
     - ginkgolinter
-    # - gocritic
+    - gocritic
     # - govet        
     # - loggercheck
     # - misspell

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
     - makezero
     - errcheck
     - goconst
-    - gofmt
     - goimports
     - gosimple
     - ineffassign

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -19,7 +19,7 @@ linters:
     - fatcontext
     - ginkgolinter
     - gocritic
-    # - govet        
+    # - govet        # do not enable - this causes some metalinter issue
     - loggercheck
     - misspell
     - perfsprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,9 @@ linters:
     - dupword
     - durationcheck
     - fatcontext
-    # - ginkgolinter
-    # - gocritic
-    # - govet        
+    - ginkgolinter
+    - gocritic
+    - govet        
     # - loggercheck
     # - misspell
     # - perfsprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   timeout: 5m
   allow-parallel-runners: true
-    
+
 # Settings related to issues
 issues:
   # Report issues on new code only (since we're brining in from upstream)
@@ -9,8 +9,6 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
-  exclude-files:
-    - '^pkg/epp/server/runserver_test\.go$'
     
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,13 +9,7 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
-  exclude-files:
-    - '^some/other/file\.go$'   # if you still need it elsewhere
-  exclude-rules:
-    - path: '^pkg/epp/server/runserver_test\.go$'
-      linters:
-        - typecheck
-        
+    
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   timeout: 5m
   allow-parallel-runners: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,3 @@
-version: "2"
-
 run:
   timeout: 5m
   allow-parallel-runners: true
@@ -11,9 +9,6 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
-  # Files to exclude from linting
-  # exclude-files:
-  #   - pkg/epp/server/runserver_test.go
     
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,7 +3,9 @@ version: "2"
 run:
   timeout: 5m
   allow-parallel-runners: true
-
+  skip-files:
+    - '^pkg/epp/server/runserver_test\.go$'
+    
 # Settings related to issues
 issues:
   # Report issues on new code only (since we're brining in from upstream)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -21,7 +21,7 @@ linters:
     - fatcontext
     - ginkgolinter
     - gocritic
-    - govet
+    - govet        
     - loggercheck
     - misspell
     - perfsprint
@@ -36,10 +36,9 @@ linters:
     - ineffassign
     - nakedret
     - prealloc
-    - typecheck
     - unparam
     - unused
-    
+
 linters-settings:
   revive:
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 run:
   timeout: 5m
   allow-parallel-runners: true
-    
+
 # Settings related to issues
 issues:
   # Report issues on new code only (since we're brining in from upstream)
@@ -14,26 +14,30 @@ linters:
   disable-all: true
   enable:
     - copyloopvar
-    # - dupword
-    # - durationcheck
-    # - fatcontext
-    # - ginkgolinter
-    # - gocritic
-    # - govet        
-    # - loggercheck
-    # - misspell
-    # - perfsprint
-    # - revive
-    # - unconvert
-    # - makezero
-    # - errcheck
-    # - goconst
-    # - ineffassign
-    # - nakedret
-    # - prealloc
-    # - unparam
-    # - unused
-
+    - dupword
+    - durationcheck
+    - fatcontext
+    - ginkgolinter
+    - gocritic
+    - govet
+    - loggercheck
+    - misspell
+    - perfsprint
+    - revive
+    - unconvert
+    - makezero
+    - errcheck
+    - goconst
+    - gofmt
+    - goimports
+    - gosimple
+    - ineffassign
+    - nakedret
+    - prealloc
+    - typecheck
+    - unparam
+    - unused
+    
 linters-settings:
   revive:
     rules:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,13 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
-    
+  exclude-files:
+    - '^some/other/file\.go$'   # if you still need it elsewhere
+  exclude-rules:
+    - path: '^pkg/epp/server/runserver_test\.go$'
+      linters:
+        - typecheck
+        
 linters:
   disable-all: true
   enable:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -37,7 +37,7 @@ linters:
     - nakedret
     - prealloc
     - unparam
-    - unused
+    # - unused
 
 linters-settings:
   revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,8 +3,6 @@ version: "2"
 run:
   timeout: 5m
   allow-parallel-runners: true
-  skip-files:
-    - '^pkg/epp/server/runserver_test\.go$'
     
 # Settings related to issues
 issues:
@@ -13,8 +11,9 @@ issues:
   # Which dirs to exclude: issues from them won't be reported
   exclude-dirs:
     - bin
+  # Files to exclude from linting
   exclude-files:
-    - '^pkg/epp/server/runserver_test\.go$'
+    - pkg/epp/server/runserver_test.go
     
 linters:
   disable-all: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,19 +20,19 @@ linters:
     - ginkgolinter
     - gocritic
     # - govet        
-    # - loggercheck
-    # - misspell
-    # - perfsprint
-    # - revive
-    # - unconvert
-    # - makezero
-    # - errcheck
-    # - goconst
-    # - ineffassign
-    # - nakedret
-    # - prealloc
-    # - unparam
-    # - unused
+    - loggercheck
+    - misspell
+    - perfsprint
+    - revive
+    - unconvert
+    - makezero
+    - errcheck
+    - goconst
+    - ineffassign
+    - nakedret
+    - prealloc
+    - unparam
+    - unused
 
 linters-settings:
   revive:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -18,8 +18,8 @@ linters:
     - durationcheck
     - fatcontext
     - ginkgolinter
-    - gocritic
-    - govet        
+    # - gocritic
+    # - govet        
     # - loggercheck
     # - misspell
     # - perfsprint

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   timeout: 5m
   allow-parallel-runners: true
   skip-files:
-    - "pkg/epp/server/runserver_test.go"
+    - '^pkg/epp/server/runserver_test\.go$'
     
 # Settings related to issues
 issues:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,6 @@ linters:
     - makezero
     - errcheck
     - goconst
-    - gosimple
     - ineffassign
     - nakedret
     - prealloc

--- a/.tekton/buildah-build.yaml
+++ b/.tekton/buildah-build.yaml
@@ -44,6 +44,15 @@ spec:
         USERNAME=$(jq -r '.auths["quay.io"].username' /root/.docker/config.json)
         PASSWORD=$(jq -r '.auths["quay.io"].password' /root/.docker/config.json)
 
+        echo "🔐 Extracting Git credentials from workspace..."
+        GIT_USER=$(cat /workspace/git-auth/username)
+        GIT_TOKEN=$(cat /workspace/git-auth/token)
+
+        if [ -z "$GIT_USER" ] || [ -z "$GIT_TOKEN" ]; then
+          echo "❌ Error: Missing git-auth credentials"
+          exit 1
+        fi
+        
         if [ "$USERNAME" = "null" ] || [ "$PASSWORD" = "null" ]; then
           echo "❌ Error: Missing registry credentials"
           exit 1
@@ -56,8 +65,10 @@ spec:
         export DOCKER_CONFIG=/root/.docker
         export BUILDER=buildah
         export IMG=$(params.image_tag_base):$(params.dev-version)
-
+        export GIT_NM_USER=$GIT_USER 
+        export NM_TOKEN=$GIT_TOKEN
+        
         echo "🚀 Calling make buildah-build with IMG=$IMG..."
-        make buildah-build IMG=$IMG
+        make buildah-build IMG=$IMG 
 
         echo "$IMG" > /tekton/results/image-url

--- a/.tekton/go-build-task.yaml
+++ b/.tekton/go-build-task.yaml
@@ -28,5 +28,8 @@ spec:
         git config --global url."https://${GIT_USER}:${GIT_TOKEN}@github.com".insteadOf "https://github.com"
         git config --global --add safe.directory "$(pwd)"
 
+        # required for go build with tokenizer lib linking
+        dnf install -y gcc-c++ libstdc++ libstdc++-devel && dnf clean all
+        
         go env -w GOFLAGS=-buildvcs=false
         make build

--- a/.tekton/go-build-task.yaml
+++ b/.tekton/go-build-task.yaml
@@ -12,5 +12,21 @@ spec:
       script: |
         #!/bin/bash
         cd $(workspaces.source.path)
+
+        echo "🔐 Extracting Git credentials from workspace..."
+        GIT_USER=$(cat /workspace/git-auth/username)
+        GIT_TOKEN=$(cat /workspace/git-auth/token)
+
+        if [ -z "$GIT_USER" ] || [ -z "$GIT_TOKEN" ]; then
+          echo "❌ Error: Missing git-auth credentials"
+          exit 1
+        fi
+
+        echo "🔐 Configuring Git..."
+        git config --global user.email "ci-tag-bot@example.com"
+        git config --global user.name "ci-tag-bot"
+        git config --global url."https://${GIT_USER}:${GIT_TOKEN}@github.com".insteadOf "https://github.com"
+        git config --global --add safe.directory "$(pwd)"
+
         go env -w GOFLAGS=-buildvcs=false
         make build

--- a/.tekton/go-lint-task.yaml
+++ b/.tekton/go-lint-task.yaml
@@ -10,7 +10,8 @@ spec:
     - name: source
   steps:
     - name: run-lint
-      image: us.icr.io/ibm-hc4ai-operator/golangci-lint:v2.0.3
+      image: us.icr.io/ibm-hc4ai-operator/golangci-lint:v1.64.8
+      # image: us.icr.io/ibm-hc4ai-operator/golangci-lint:v2.0.3
       imagePullPolicy: IfNotPresent
       script: |
         #!/bin/bash

--- a/.tekton/go-lint-task.yaml
+++ b/.tekton/go-lint-task.yaml
@@ -10,7 +10,7 @@ spec:
     - name: source
   steps:
     - name: run-lint
-      image: us.icr.io/ibm-hc4ai-operator/golangci-lint:v1.64.8
+      image: us.icr.io/ibm-hc4ai-operator/golangci-lint:v2.0.3
       imagePullPolicy: IfNotPresent
       script: |
         #!/bin/bash

--- a/.tekton/pipelinerun.yaml
+++ b/.tekton/pipelinerun.yaml
@@ -165,6 +165,9 @@ spec:
         workspaces:
           - name: source
             workspace: source
+          - name: git-auth
+            workspace: git-auth
+
 
       - name: extract-version-and-registry
         params:

--- a/.tekton/pipelinerun.yaml
+++ b/.tekton/pipelinerun.yaml
@@ -331,6 +331,8 @@ spec:
             workspace: registry-secret
           - name: container-storage
             workspace: container-storage
+          - name: git-auth
+            workspace: git-auth
 
       - name: vulnerability-scan
         when:

--- a/Makefile
+++ b/Makefile
@@ -494,6 +494,7 @@ image-build: check-container-tool load-version-json ## Build container image usi
 		--build-arg TARGETARCH=$(TARGETARCH) \
 		--build-arg GIT_NM_USER=$(GIT_NM_USER)\
         --build-arg NM_TOKEN=$(NM_TOKEN) \
+		--progress=plain \
  		-t $(IMG) .
 
 .PHONY: image-push

--- a/README.md
+++ b/README.md
@@ -22,6 +22,11 @@ To enable LoadAwareScorer, the following env vars must be configured:
 export ENABLE_LOAD_AWARE_SCORER=true
 export LOAD_AWARE_SCORER_WEIGHT=1.0
 ```
+
+To enable PDFilter, the following env var must be configured:
+```
+export ENABLE_PD_FILTER=true
+```
 ---
 [Inference Gateways]:#concepts-and-definitions
 
@@ -96,8 +101,8 @@ See our website at https://gateway-api-inference-extension.sigs.k8s.io/ for deta
 ## Roadmap
 
 As Inference Gateway builds towards a GA release. We will continue to expand our capabilities, namely:
-1. Prefix-cache aware load balancing with interfaces for remote caches 
-1. Recommended LoRA adapter pipeline for automated rollout 
+1. Prefix-cache aware load balancing with interfaces for remote caches
+1. Recommended LoRA adapter pipeline for automated rollout
 1. Fairness and priority between workloads within the same criticality band
 1. HPA support for autoscaling on aggregate metrics derived from the load balancer
 1. Support for large multi-modal inputs and outputs
@@ -121,4 +126,3 @@ Contributions are readily welcomed, follow the [dev guide](./docs/dev.md) to sta
 ### Code of conduct
 
 Participation in the Kubernetes community is governed by the [Kubernetes Code of Conduct](code-of-conduct.md).
-

--- a/pkg/epp/backend/metrics/pod_metrics.go
+++ b/pkg/epp/backend/metrics/pod_metrics.go
@@ -32,7 +32,7 @@ import (
 
 const (
 	fetchMetricsTimeout = 5 * time.Second
-	roleLabel           = "llmd.org/role"
+	roleLabel           = "llm-d.ai/role"
 	rolePrefill         = "prefill"
 	roleDecode          = "decode"
 	roleBoth            = "both"

--- a/pkg/epp/handlers/request.go
+++ b/pkg/epp/handlers/request.go
@@ -90,7 +90,7 @@ func (s *StreamingServer) HandleRequestBody(
 		return reqCtx, errutil.Error{Code: errutil.Internal, Msg: fmt.Sprintf("error marshaling request body: %v", err)}
 	}
 
-	res, err := s.scheduler.Schedule(ctx, llmReq)
+	res, err := s.scheduler.OnRequest(ctx, llmReq)
 	if err != nil {
 		return reqCtx, errutil.Error{Code: errutil.InferencePoolResourceExhausted, Msg: fmt.Errorf("failed to find target pod: %w", err).Error()}
 	}

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -66,8 +66,8 @@ type StreamingServer struct {
 }
 
 type Scheduler interface {
-	Schedule(ctx context.Context, b *schedulingtypes.LLMRequest) (result *schedulingtypes.Result, err error)
 	RunPostResponsePlugins(ctx context.Context, req *types.LLMRequest, tragetPodName string) (*schedulingtypes.Result, error)
+	OnRequest(ctx context.Context, b *schedulingtypes.LLMRequest) (result *schedulingtypes.Result, err error)
 }
 
 // RequestContext stores context information during the life time of an HTTP request.

--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -66,8 +66,8 @@ type StreamingServer struct {
 }
 
 type Scheduler interface {
-	RunPostResponsePlugins(ctx context.Context, req *types.LLMRequest, tragetPodName string) (*schedulingtypes.Result, error)
 	OnRequest(ctx context.Context, b *schedulingtypes.LLMRequest) (result *schedulingtypes.Result, err error)
+	OnResponse(ctx context.Context, req *types.LLMRequest, tragetPodName string) (*schedulingtypes.Result, error)
 }
 
 // RequestContext stores context information during the life time of an HTTP request.
@@ -212,7 +212,7 @@ func (s *StreamingServer) Process(srv extProcPb.ExternalProcessor_ProcessServer)
 			}
 
 			var result *types.Result
-			result, err = s.scheduler.RunPostResponsePlugins(ctx, llmReq, reqCtx.TargetPod)
+			result, err = s.scheduler.OnResponse(ctx, llmReq, reqCtx.TargetPod)
 			if err != nil {
 				logger.V(logutil.DEFAULT).Error(err, "Error handling response")
 				reqCtx.ResponseStatusCode = errutil.ModelServerError

--- a/pkg/epp/scheduling/config.go
+++ b/pkg/epp/scheduling/config.go
@@ -26,6 +26,7 @@ type SchedulerConfig struct {
 	scorers             map[plugins.Scorer]int // map from scorer to weight
 	picker              plugins.Picker
 	postSchedulePlugins []plugins.PostSchedule
+	postResponsePlugins []plugins.PostResponse
 }
 
 var defPlugin = &defaultPlugin{}
@@ -40,4 +41,5 @@ var defaultConfig = &SchedulerConfig{
 	scorers:             map[plugins.Scorer]int{},
 	picker:              defPlugin,
 	postSchedulePlugins: []plugins.PostSchedule{},
+	postResponsePlugins: []plugins.PostResponse{},
 }

--- a/pkg/epp/scheduling/local_config.go
+++ b/pkg/epp/scheduling/local_config.go
@@ -36,6 +36,10 @@ const (
 	loadAwareScorerWeightEnvVar = "LOAD_AWARE_SCORER_WEIGHT"
 )
 
+func init() {
+	setDefaultConfig()
+}
+
 func setDefaultConfig() {
 	// since the default config is a global variable, we add this function to minimize rebase conflicts.
 	// this configuration is a temporary state, it should be better streamlined.

--- a/pkg/epp/scheduling/local_config.go
+++ b/pkg/epp/scheduling/local_config.go
@@ -18,7 +18,9 @@ package scheduling
 
 import (
 	"context"
+
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins/filter"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins/picker"
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/scheduling/plugins/scorer"
 	envutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/env"
@@ -28,6 +30,7 @@ import (
 const (
 	kvCacheScorerEnablementEnvVar   = "ENABLE_KVCACHE_AWARE_SCORER"
 	loadAwareScorerEnablementEnvVar = "ENABLE_LOAD_AWARE_SCORER"
+	pdFilterEnablementEnvVar        = "ENABLE_PD_FILTER"
 
 	kvCacheScorerWeightEnvVar   = "KVCACHE_AWARE_SCORER_WEIGHT"
 	loadAwareScorerWeightEnvVar = "LOAD_AWARE_SCORER_WEIGHT"
@@ -38,6 +41,7 @@ func setDefaultConfig() {
 	// this configuration is a temporary state, it should be better streamlined.
 	setLoadAwareScorer()
 	setKVCacheAwareScorer()
+	setPDFilter()
 
 	defaultConfig.picker = picker.NewMaxScorePicker()
 }
@@ -74,4 +78,16 @@ func setKVCacheAwareScorer() {
 	kvCacheScorerWeight := envutil.GetEnvInt(kvCacheScorerWeightEnvVar, 1, loggerDebug)
 	defaultConfig.scorers[kvCacheScorer] = kvCacheScorerWeight
 	loggerDebug.Info("Initialized KVCacheAwareScorer", "weight", kvCacheScorerWeight)
+}
+
+func setPDFilter() {
+	ctx := context.Background()
+	loggerDebug := log.FromContext(ctx).WithName("scheduler_config").V(logutil.DEBUG)
+
+	if envutil.GetEnvString(pdFilterEnablementEnvVar, "false", loggerDebug) != "true" {
+		loggerDebug.Info("Skipping PDFilter creation as it is not enabled")
+		return
+	}
+
+	defaultConfig.filters = append(defaultConfig.filters, filter.PDFilter)
 }

--- a/pkg/epp/scheduling/local_config.go
+++ b/pkg/epp/scheduling/local_config.go
@@ -90,4 +90,5 @@ func setPDFilter() {
 	}
 
 	defaultConfig.filters = append(defaultConfig.filters, filter.PDFilter)
+	loggerDebug.Info("Initialized PDFilter")
 }

--- a/pkg/epp/scheduling/plugins/filter/pd_filter.go
+++ b/pkg/epp/scheduling/plugins/filter/pd_filter.go
@@ -44,7 +44,7 @@ var PDFilter = &baseFilter{
 // Returns:
 //   - Filtered slice of pod metrics, could contain one or zerro elements
 func prefillDecodeFilterFunc(ctx *types.SchedulingContext, pods []types.Pod) []types.Pod {
-	logger := log.FromContext(ctx).WithName("p/d filter").V(logutil.DEBUG)
+	loggerDebug := log.FromContext(ctx).WithName("pd_filter").V(logutil.DEBUG)
 
 	pPods := make([]types.Pod, 0)
 	dPods := make([]types.Pod, 0)
@@ -61,7 +61,7 @@ func prefillDecodeFilterFunc(ctx *types.SchedulingContext, pods []types.Pod) []t
 		// select a random prefill pod
 		randomIndex := rand.IntN(len(pPods))
 		url := fmt.Sprintf("http://%s:%d", pPods[randomIndex].GetPod().Address, ctx.TargetPort)
-		logger.Info("prefill pod selected", "url", url)
+		loggerDebug.Info("Prefill pod selected", "url", url)
 
 		ctx.MutatedHeaders[prefillPodHeader] = url
 	}

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -212,6 +212,38 @@ func (s *Scheduler) runPostSchedulePlugins(ctx *types.SchedulingContext, res *ty
 	}
 }
 
+func (s *Scheduler) RunPostResponsePlugins(ctx context.Context, req *types.LLMRequest, targetPodName string) (*types.Result, error) {
+	logger := log.FromContext(ctx)
+
+	pool, err := s.datastore.PoolGet()
+	if err != nil {
+		return nil, errutil.Error{Code: errutil.Internal, Msg: "failed to find a target pod"} // pool not defined, no pods
+	}
+
+	// Snapshot pod metrics from the datastore to:
+	// 1. Reduce concurrent access to the datastore.
+	// 2. Ensure consistent data during the scheduling operation of a request.
+	pods := types.ToSchedulerPodMetrics(s.datastore.PodGetAll())
+	var targetPod types.Pod
+	for _, pod := range pods {
+		if pod.GetPod().NamespacedName.String() == targetPodName {
+			targetPod = pod
+			break
+		}
+	}
+
+	sCtx := types.NewSchedulingContext(ctx, req, pods, pool.Spec.TargetPortNumber)
+
+	for _, plugin := range s.postResponsePlugins {
+		logger.V(logutil.DEBUG).Info("Running post-response plugin", "plugin", plugin.Name())
+		before := time.Now()
+		plugin.PostResponse(sCtx, targetPod)
+		metrics.RecordSchedulerPluginProcessingLatency(plugins.PostResponsePluginType, plugin.Name(), time.Since(before))
+	}
+
+	return &types.Result{TargetPod: nil, MutatedHeaders: sCtx.MutatedHeaders}, nil
+}
+
 type defaultPlugin struct {
 	picker.RandomPicker
 }

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -69,7 +69,6 @@ var (
 )
 
 func NewScheduler(datastore Datastore) *Scheduler {
-	setDefaultConfig()
 	return NewSchedulerWithConfig(datastore, defaultConfig)
 }
 

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -81,6 +81,7 @@ func NewSchedulerWithConfig(datastore Datastore, config *SchedulerConfig) *Sched
 		scorers:             config.scorers,
 		picker:              config.picker,
 		postSchedulePlugins: config.postSchedulePlugins,
+		postResponsePlugins: config.postResponsePlugins,
 	}
 }
 
@@ -91,6 +92,7 @@ type Scheduler struct {
 	scorers             map[plugins.Scorer]int // map from scorer to its weight
 	picker              plugins.Picker
 	postSchedulePlugins []plugins.PostSchedule
+	postResponsePlugins []plugins.PostResponse
 }
 
 type Datastore interface {

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -99,8 +99,10 @@ type Datastore interface {
 	PodGetAll() []backendmetrics.PodMetrics
 }
 
-// Schedule finds the target pod based on metrics and the requested lora adapter.
-func (s *Scheduler) Schedule(ctx context.Context, req *types.LLMRequest) (*types.Result, error) {
+// OnRequest finds the target pod based on metrics and the requested lora adapter.
+// OnRequest is invoked during the processing of the request, before it is sent to
+// appropriate pod for inference
+func (s *Scheduler) OnRequest(ctx context.Context, req *types.LLMRequest) (*types.Result, error) {
 	logger := log.FromContext(ctx).WithValues("request", req)
 	loggerDebug := logger.V(logutil.DEBUG)
 

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -518,7 +518,7 @@ func TestPostResponse(t *testing.T) {
 			Headers: test.responseHeaders,
 		}
 
-		result, err := scheduler.RunPostResponsePlugins(context.Background(), req, test.input[0].Pod.NamespacedName.String())
+		result, err := scheduler.OnResponse(context.Background(), req, test.input[0].Pod.NamespacedName.String())
 		if err != nil {
 			t.Errorf("Received an error. Error: %s", err)
 		}

--- a/pkg/epp/scheduling/scheduler_test.go
+++ b/pkg/epp/scheduling/scheduler_test.go
@@ -232,7 +232,7 @@ func TestSchedule(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			scheduler := NewScheduler(&fakeDataStore{pods: test.input})
-			got, err := scheduler.Schedule(context.Background(), test.req)
+			got, err := scheduler.OnRequest(context.Background(), test.req)
 			if test.err != (err != nil) {
 				t.Errorf("Unexpected error, got %v, want %v", err, test.err)
 			}
@@ -407,7 +407,7 @@ func TestSchedulePlugins(t *testing.T) {
 				Model:   "test-model",
 				Headers: test.requestHeaders,
 			}
-			got, err := scheduler.Schedule(context.Background(), req)
+			got, err := scheduler.OnRequest(context.Background(), req)
 
 			// Validate error state
 			if test.err != (err != nil) {

--- a/pkg/epp/scheduling/scorers_test.go
+++ b/pkg/epp/scheduling/scorers_test.go
@@ -86,19 +86,23 @@ func TestScorers(t *testing.T) {
 				},
 			},
 			wantRes: &types.Result{
-				TargetPod: &types.PodMetrics{
-					Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
-					Metrics: &backendmetrics.Metrics{
-						WaitingQueueSize:    0,
-						KVCacheUsagePercent: 0.2,
-						MaxActiveModels:     2,
-						ActiveModels: map[string]int{
-							"foo": 1,
-							"bar": 1,
+				TargetPod: &types.ScoredPod{
+					Pod: &types.PodMetrics{
+						Pod: &backendmetrics.Pod{NamespacedName: k8stypes.NamespacedName{Name: "pod2"}},
+						Metrics: &backendmetrics.Metrics{
+							WaitingQueueSize:    0,
+							KVCacheUsagePercent: 0.2,
+							MaxActiveModels:     2,
+							ActiveModels: map[string]int{
+								"foo": 1,
+								"bar": 1,
+							},
+							WaitingModels: map[string]int{},
 						},
-						WaitingModels: map[string]int{},
 					},
+					Score: 0.5,
 				},
+				MutatedHeaders: map[string]string{},
 			},
 		},
 	}

--- a/pkg/epp/scheduling/scorers_test.go
+++ b/pkg/epp/scheduling/scorers_test.go
@@ -112,7 +112,7 @@ func TestScorers(t *testing.T) {
 			scheduler := NewScheduler(&fakeDataStore{pods: test.input})
 			scheduler.scorers = map[plugins.Scorer]int{test.scorer: 1}
 			scheduler.picker = &picker.MaxScorePicker{}
-			got, err := scheduler.Schedule(context.Background(), test.req)
+			got, err := scheduler.OnRequest(context.Background(), test.req)
 			if test.err != (err != nil) {
 				t.Errorf("Unexpected error, got %v, want %v", err, test.err)
 			}

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -18,7 +18,7 @@ package server_test
 import (
 	"testing"
 
-	. "sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/server"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -27,7 +27,7 @@ import (
 func TestRunnable(t *testing.T) {
 	// Make sure AsRunnable() does not use leader election.
 	runner := server.NewDefaultExtProcServerRunner().AsRunnable(logutil.NewTestLogger())
-	r, ok := runner.(LeaderElectionRunnable)
+	r, ok := runner.(manager.LeaderElectionRunnable)
 	if !ok {
 		t.Fatal("runner is not LeaderElectionRunnable")
 	}

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// nolint
 package server_test
 
 import (

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -16,6 +16,8 @@ limitations under the License.
 
 package server_test
 
+//nolint:typecheck
+
 import (
 	"testing"
 

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package server_test
 
-//nolint:typecheck
-
 import (
 	"testing"
 

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -18,7 +18,7 @@ package server_test
 import (
 	"testing"
 
-	"sigs.k8s.io/controller-runtime/pkg/manager"
+	. "sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"sigs.k8s.io/gateway-api-inference-extension/pkg/epp/server"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
@@ -27,7 +27,7 @@ import (
 func TestRunnable(t *testing.T) {
 	// Make sure AsRunnable() does not use leader election.
 	runner := server.NewDefaultExtProcServerRunner().AsRunnable(logutil.NewTestLogger())
-	r, ok := runner.(manager.LeaderElectionRunnable)
+	r, ok := runner.(LeaderElectionRunnable)
 	if !ok {
 		t.Fatal("runner is not LeaderElectionRunnable")
 	}

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +13,6 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-
-// nolint
 package server_test
 
 import (

--- a/pkg/epp/server/runserver_test.go
+++ b/pkg/epp/server/runserver_test.go
@@ -24,6 +24,9 @@ import (
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/epp/util/logging"
 )
 
+// Define a variable with the manager package type to explicitly show usage to linter
+var _ manager.LeaderElectionRunnable = nil
+
 func TestRunnable(t *testing.T) {
 	// Make sure AsRunnable() does not use leader election.
 	runner := server.NewDefaultExtProcServerRunner().AsRunnable(logutil.NewTestLogger())


### PR DESCRIPTION
The PR renames the two APIs of the Scheduler. In particular:

  - Scheduler.Schedule has been renamed scheduler.OnRequest to better indicate that it is invoked during request processing.
  - Scheduler.RunPostResponsePlugins has been renamed to Scheduler.OnResponse to both indicate that it is invoked during response processing and to better decouple it from PostResponse plugin handling
 
In addition the code in the function Scheduler.OnResponse that is specific to PostResponse plugin handling has been moved to a new private function Scheduler.runPostResponsePlugins, in the style of th functions that drive the handling of the other plugins.