### PR TITLE
Add decode filter to the default filters list in case pd is enabled

### DIFF
--- a/pkg/epp/scheduling/pd_config.go
+++ b/pkg/epp/scheduling/pd_config.go
@@ -57,6 +57,11 @@ func init() {
 	// set IsPDEnabled by environment
 	PDEnabled = getPDEnabledFromEnvironment(loggerDebug)
 	promptLengthThreshold = getPDPromptLenThresholdFromEnvironment(loggerDebug)
+
+	// update default config if pd is enabled
+	if PDEnabled {
+		defaultConfig.filters = append(defaultConfig.filters, filter.DecodeFilter)
+	}
 }
 
 func loadPrefillConfiguration(ctx context.Context, logger logr.Logger) {


### PR DESCRIPTION
When PD is enabled and the default scheduling config is used we need to make sure that the request is not send to prefill pod
