### PR TITLE
Update Istio release

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -35,6 +35,13 @@ serving resources.
 > simulator separately on your local system. In a future iteration this will
 > be handled automatically and will not be required.
 
+> **Note**: If you would like to use Istio as the Gateway implementation, you
+> currently need to opt-in to that. Set the following environment variables
+> before running make:
+>
+>   export GATEWAY_IMPLEMENTATION=istio
+>   export GATEWAY_CONTROL_PLANE_NAMESPACE=istio-system
+
 Run the following:
 
 ```bash

--- a/deploy/components/crds-istio/istio.yaml
+++ b/deploy/components/crds-istio/istio.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: authorizationpolicies.security.istio.io
 spec:
   group: security.istio.io
@@ -775,8 +775,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: destinationrules.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6545,8 +6545,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: envoyfilters.networking.istio.io
 spec:
   group: networking.istio.io
@@ -6954,8 +6954,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: gateways.networking.istio.io
 spec:
   group: networking.istio.io
@@ -7681,8 +7681,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: peerauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -8035,8 +8035,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: proxyconfigs.networking.istio.io
 spec:
   group: networking.istio.io
@@ -8189,8 +8189,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: requestauthentications.security.istio.io
 spec:
   group: security.istio.io
@@ -8783,8 +8783,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: serviceentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -9705,8 +9705,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: sidecars.networking.istio.io
 spec:
   group: networking.istio.io
@@ -11357,8 +11357,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: telemetries.telemetry.istio.io
 spec:
   group: telemetry.istio.io
@@ -12281,8 +12281,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: virtualservices.networking.istio.io
 spec:
   group: networking.istio.io
@@ -15444,8 +15444,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: wasmplugins.extensions.istio.io
 spec:
   group: extensions.istio.io
@@ -15806,8 +15806,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: workloadentries.networking.istio.io
 spec:
   group: networking.istio.io
@@ -16312,8 +16312,8 @@ metadata:
     app.kubernetes.io/instance: istio
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
   name: workloadgroups.networking.istio.io
 spec:
   group: networking.istio.io

--- a/deploy/components/inference-gateway/deployments.yaml
+++ b/deploy/components/inference-gateway/deployments.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 130
       containers:
       - name: epp
-        image: quay.io/llm-d/gateway-api-inference-extension:latest
+        image: quay.io/llm-d/gateway-api-inference-extension/epp:latest
         imagePullPolicy: IfNotPresent
         args:
         - -poolName

--- a/deploy/components/inference-gateway/kustomization.yaml
+++ b/deploy/components/inference-gateway/kustomization.yaml
@@ -28,5 +28,5 @@ resources:
 - httproutes.yaml
 
 images:
-- name: quay.io/llm-d/gateway-api-inference-extension
+- name: quay.io/llm-d/gateway-api-inference-extension/epp
   newTag: 0.0.1

--- a/deploy/components/istio-control-plane/configmaps.yaml
+++ b/deploy/components/istio-control-plane/configmaps.yaml
@@ -17,14 +17,15 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot
     release: istio
   name: istio
   namespace: istio-system
+
 ---
 apiVersion: v1
 data:
@@ -1971,7 +1972,7 @@ data:
         "sts": {
           "servicePort": 0
         },
-        "tag": "1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f",
+        "tag": "1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d",
         "variant": "",
         "waypoint": {
           "affinity": {},
@@ -2015,8 +2016,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot

--- a/deploy/components/istio-control-plane/deployments.yaml
+++ b/deploy/components/istio-control-plane/deployments.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default
@@ -36,8 +36,8 @@ spec:
         app.kubernetes.io/managed-by: Helm
         app.kubernetes.io/name: istiod
         app.kubernetes.io/part-of: istio
-        app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-        helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+        app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+        helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
         install.operator.istio.io/owning-resource: unknown
         istio: pilot
         istio.io/dataplane-mode: none
@@ -95,7 +95,7 @@ spec:
               resource: limits.cpu
         - name: PLATFORM
           value: ""
-        image: gcr.io/istio-testing/pilot:1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+        image: gcr.io/istio-testing/pilot:1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
         name: discovery
         ports:
         - containerPort: 8080

--- a/deploy/components/istio-control-plane/hpa.yaml
+++ b/deploy/components/istio-control-plane/hpa.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot

--- a/deploy/components/istio-control-plane/policies.yaml
+++ b/deploy/components/istio-control-plane/policies.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-ingressgateway
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istio-ingress-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a7
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istio-ingress-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc
     install.operator.istio.io/owning-resource: unknown
     istio: ingressgateway
     istio.io/rev: default
@@ -22,6 +22,7 @@ spec:
     matchLabels:
       app: istio-ingressgateway
       istio: ingressgateway
+
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -32,8 +33,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default

--- a/deploy/components/istio-control-plane/rbac.yaml
+++ b/deploy/components/istio-control-plane/rbac.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-reader
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istio-reader-clusterrole-istio-system
 rules:
@@ -111,6 +111,7 @@ rules:
   - subjectaccessreviews
   verbs:
   - create
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -121,8 +122,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod-clusterrole-istio-system
 rules:
@@ -346,6 +347,7 @@ rules:
   - get
   - watch
   - list
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -356,8 +358,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod-gateway-controller-istio-system
 rules:
@@ -408,8 +410,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-reader
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istio-reader-clusterrole-istio-system
 roleRef:
@@ -431,8 +433,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod-clusterrole-istio-system
 roleRef:
@@ -454,8 +456,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod-gateway-controller-istio-system
 roleRef:
@@ -466,6 +468,7 @@ subjects:
 - kind: ServiceAccount
   name: istiod
   namespace: istio-system
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -475,8 +478,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-ingressgateway
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istio-ingress-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a7
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istio-ingress-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: IngressGateways
@@ -503,8 +506,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod
   namespace: istio-system
@@ -551,8 +554,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-ingressgateway
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istio-ingress-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a7
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istio-ingress-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: IngressGateways
@@ -566,6 +569,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: istio-ingressgateway-service-account
+
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -576,8 +580,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod
   namespace: istio-system

--- a/deploy/components/istio-control-plane/service-accounts.yaml
+++ b/deploy/components/istio-control-plane/service-accounts.yaml
@@ -7,11 +7,12 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istio-reader
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: base-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: base-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istio-reader-service-account
   namespace: istio-system
+
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -22,8 +23,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     release: istio
   name: istiod
   namespace: istio-system

--- a/deploy/components/istio-control-plane/services.yaml
+++ b/deploy/components/istio-control-plane/services.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio: pilot
     istio.io/rev: default

--- a/deploy/components/istio-control-plane/webhooks.yaml
+++ b/deploy/components/istio-control-plane/webhooks.yaml
@@ -7,8 +7,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     istio: istiod
     istio.io/rev: default
     release: istio
@@ -53,8 +53,8 @@ metadata:
     app.kubernetes.io/managed-by: Helm
     app.kubernetes.io/name: istiod
     app.kubernetes.io/part-of: istio
-    app.kubernetes.io/version: 1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
-    helm.sh/chart: istiod-1.26-alpha.80c74f7f43482c226f4f4b10b4dda6261b67a71f
+    app.kubernetes.io/version: 1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
+    helm.sh/chart: istiod-1.26-alpha.9befed2f1439d883120f8de70fd70d84ca0ebc3d
     install.operator.istio.io/owning-resource: unknown
     istio.io/rev: default
     operator.istio.io/component: Pilot

--- a/deploy/environments/dev/kubernetes-istio/kustomization.yaml
+++ b/deploy/environments/dev/kubernetes-istio/kustomization.yaml
@@ -12,7 +12,7 @@ images:
 - name: quay.io/llm-d/vllm-sim
   newName: ${VLLM_SIM_IMAGE}
   newTag: ${VLLM_SIM_TAG}
-- name: quay.io/llm-d/llm-d-gateway-api-inference-extension
+- name: quay.io/llm-d/gateway-api-inference-extension/epp
   newName: ${EPP_IMAGE}
   newTag: ${EPP_TAG}
 

--- a/deploy/environments/dev/kubernetes-kgateway/kustomization.yaml
+++ b/deploy/environments/dev/kubernetes-kgateway/kustomization.yaml
@@ -9,7 +9,7 @@ resources:
 - gateway-parameters.yaml
 
 images:
-- name: quay.io/llm-d/gateway-api-inference-extension
+- name: quay.io/llm-d/gateway-api-inference-extension/epp
   newName: ${EPP_IMAGE}
   newTag: ${EPP_TAG}
 


### PR DESCRIPTION
This updates the Istio release in our deployments to fix a [regression introduced in upstream GIE](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/740), re: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/780

Note that this PR does not switch back to Istio as the default for environments.