### PR TITLE
[UPSTREAM] Break up scheduling to allow calling with an existing context

### DIFF
--- a/pkg/epp/handlers/server.go
+++ b/pkg/epp/handlers/server.go
@@ -67,6 +67,7 @@ type StreamingServer struct {
 
 type Scheduler interface {
 	Schedule(ctx context.Context, b *schedulingtypes.LLMRequest) (result *schedulingtypes.Result, err error)
+	ScheduleWithContext(ctx *schedulingtypes.SchedulingContext, req *schedulingtypes.LLMRequest) (*schedulingtypes.Result, error)
 }
 
 // RequestContext stores context information during the life time of an HTTP request.

--- a/pkg/epp/scheduling/scheduler.go
+++ b/pkg/epp/scheduling/scheduler.go
@@ -111,6 +111,10 @@ func (s *Scheduler) Schedule(ctx context.Context, req *types.LLMRequest) (*types
 	sCtx := types.NewSchedulingContext(ctx, req, types.ToSchedulerPodMetrics(s.datastore.PodGetAll()))
 	loggerDebug.Info(fmt.Sprintf("Scheduling a request, Metrics: %+v", sCtx.PodsSnapshot))
 
+	return s.ScheduleWithContext(sCtx, req)
+}
+
+func (s *Scheduler) ScheduleWithContext(sCtx *types.SchedulingContext, req *types.LLMRequest) (*types.Result, error) {
 	s.runPreSchedulePlugins(sCtx)
 
 	pods := s.runFilterPlugins(sCtx)


### PR DESCRIPTION
Needed to allow P/D to call schedulers with an existing context and not have each scheduler create its own inside the Schedule function (e.g.,  P sets headers on a context, D creates a new scheduling context which loses the P header mutations...)