### PR TITLE
Prefix-Store Fix & KVCache-Indexer Update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,8 +3,8 @@ IMG ?= controller:latest
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 ENVTEST_K8S_VERSION = 1.31.0
 
-TARGETOS ?= linux
-TARGETARCH ?= amd64
+TARGETOS ?= $(shell go env GOOS)
+TARGETARCH ?= $(shell go env GOARCH)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-logr/logr v1.4.2
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
-	github.com/neuralmagic/llm-d-kv-cache-manager v0.0.0-20250430102735-86595011431d
+	github.com/neuralmagic/llm-d-kv-cache-manager v0.0.0-20250508211654-1fbe7c5f15e9
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
 	github.com/prometheus/client_golang v1.22.0

--- a/go.sum
+++ b/go.sum
@@ -159,6 +159,8 @@ github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/neuralmagic/llm-d-kv-cache-manager v0.0.0-20250430102735-86595011431d h1:6YSxvAG4ve5jy0nTLs509OMU5fuiQ3JNQdZxqiu8PgQ=
 github.com/neuralmagic/llm-d-kv-cache-manager v0.0.0-20250430102735-86595011431d/go.mod h1:VB+KcEemkO1ZKpz/hgUPQMU9oSLv2uCLW6y6c+r8jkQ=
+github.com/neuralmagic/llm-d-kv-cache-manager v0.0.0-20250508211654-1fbe7c5f15e9 h1:xqVxrZoIDwCZ+065w6XyU27IZJfe6XOUmvhIpbQvoD8=
+github.com/neuralmagic/llm-d-kv-cache-manager v0.0.0-20250508211654-1fbe7c5f15e9/go.mod h1:VB+KcEemkO1ZKpz/hgUPQMU9oSLv2uCLW6y6c+r8jkQ=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=

--- a/pkg/epp/scheduling/plugins/scorer/prefix_store.go
+++ b/pkg/epp/scheduling/plugins/scorer/prefix_store.go
@@ -122,10 +122,10 @@ func (s *PrefixStore) AddEntry(modelName string, prompt string, pod *types.Names
 		// Compute the hash for the current block
 		digest.Reset()
 		if err := binary.Write(digest, binary.LittleEndian, previousHash); err != nil {
-			break
+			return fmt.Errorf("failed to write previous hash: %w", err)
 		}
 		if _, err := digest.Write(promptBytes[start:end]); err != nil {
-			break
+			return fmt.Errorf("failed to write prompt bytes: %w", err)
 		}
 
 		blockHash := digest.Sum64()

--- a/pkg/epp/scheduling/plugins/scorer/prefix_store.go
+++ b/pkg/epp/scheduling/plugins/scorer/prefix_store.go
@@ -17,6 +17,7 @@ limitations under the License.
 package scorer
 
 import (
+	"encoding/binary"
 	"fmt"
 	"k8s.io/apimachinery/pkg/types"
 	"sync"
@@ -107,20 +108,28 @@ func (s *PrefixStore) AddEntry(modelName string, prompt string, pod *types.Names
 	}
 	s.Unlock()
 
+	promptBytes := []byte(prompt)
+	previousHash := uint64(0)
+	digest := xxhash.New()
+
 	// Chunk the text into blocks and populate the cache
-	for start := 0; start < len(prompt); start += s.blockSize {
+	for start := 0; start < len(promptBytes); start += s.blockSize {
 		end := start + s.blockSize
-		if end > len(prompt) {
+		if end > len(promptBytes) {
 			break // skip partial blocks
 		}
 
 		// Compute the hash for the current block
-		digest := xxhash.New()
-		if _, err := digest.WriteString(prompt[start:end]); err != nil {
-			return fmt.Errorf("failed to compute chunk hash: %w", err)
+		digest.Reset()
+		if err := binary.Write(digest, binary.LittleEndian, previousHash); err != nil {
+			break
+		}
+		if _, err := digest.Write(promptBytes[start:end]); err != nil {
+			break
 		}
 
 		blockHash := digest.Sum64()
+		previousHash = blockHash
 
 		b, ok := cache.Get(blockHash)
 		if !ok {
@@ -154,18 +163,27 @@ func (s *PrefixStore) FindMatchingPods(prompt, modelName string) map[string]int 
 		return nil
 	}
 
+	promptBytes := []byte(prompt)
+	previousHash := uint64(0)
+	digest := xxhash.New()
+
 	matchedPods := make(map[string]int)
-	for start := 0; start < len(prompt); start += s.blockSize {
+	for start := 0; start < len(promptBytes); start += s.blockSize {
 		end := start + s.blockSize
-		if end > len(prompt) {
-			end = len(prompt)
+		if end > len(promptBytes) {
+			break // skip partial blocks
 		}
 
-		digest := xxhash.New()
-		if _, err := digest.WriteString(prompt[start:end]); err != nil {
-			return nil
+		digest.Reset()
+		if err := binary.Write(digest, binary.LittleEndian, previousHash); err != nil {
+			break
 		}
+		if _, err := digest.Write(promptBytes[start:end]); err != nil {
+			break
+		}
+
 		blockHash := digest.Sum64()
+		previousHash = blockHash
 
 		b, ok := cache.Get(blockHash)
 		if !ok {


### PR DESCRIPTION
## Summary
- improved prefix-store (performance & hit rate)
- pulled latest llm-d-kv-cache-manager updates (commit 1fbe7c5f15e9193602c5270f352d7e72e3c1b187)